### PR TITLE
Update license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git+https://github.com/HustleInc/tf.git"
   },
   "author": "Hustle",
-  "license": "CLOSED-SOURCE",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/HustleInc/tf/issues"
   },


### PR DESCRIPTION
This must have been overlooked when we open sourced it. Brings it in line with the LICENSE file