### PR TITLE
Add support for a secrets file

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ First, let's look at the basic structure of a `tf` infrastructure project and th
 Describes the purpose and contents of the infrastructure project.
 
 ### `config`
-Contains configuration files in [tfvars format](https://www.terraform.io/intro/getting-started/variables.html#from-a-file) that define the infrastructure for the region and environment. A *defaults* or *common* tfvars file is required and should define reasonable defaults to be used across environments.
+Contains configuration files in [tfvars format](https://www.terraform.io/intro/getting-started/variables.html#from-a-file) that define the infrastructure for the region and environment. A *defaults* or *common* tfvars file is required and should define reasonable defaults to be used across environments. You may also include a *secrets* tfvars file, which allows you to store secrets using a tool like [git-crypt](https://github.com/AGWA/git-crypt) while keeping the rest of your configuration in plain text, but this file is not required.
 
 Environment specific variables must be defined in the appropriate environment tfvars file. The environment config file name maps to the &lt;env&gt; argument when `tf` is invoked.
 
@@ -102,6 +102,7 @@ A project may need to further differentiate by *group* when it is necessary to d
 
     ├── config
     │   ├── defaults.tfvars
+    │   ├── secrets.tfvars
     │   ├── production
     │   │   ├── mongo-state-sp.tfvars
     │   │   └── domain-event-sp.tfvars

--- a/tf
+++ b/tf
@@ -165,6 +165,11 @@ function runCommand(args, terraformArgs, opts) {
     runArgs.push(`-var-file=../config/${args.env}/${opts.group}.tfvars`)
   }
 
+  // add secrets var file
+  if (fs.existsSync(`${args.cwd}/${args.project}/config/secrets.tfvars`)) {
+    runArgs.push(`-var-file=../config/secrets.tfvars`);
+  }
+
   // set extra vars
   if (opts.extraVars && opts.extraVars.length) {
     runArgs.push(...opts.extraVars);


### PR DESCRIPTION
Right now we encrypt any file that has sensitive information in it, but this is painful because you can't review the diff on Github. It would be better to store all the secrets in one place and reference them via vars, keeping templates in plain text.

This adds support for a `secrets.tfvars` file to solve that problem.

I thought about making the secrets file env-specific, but decided it would complicate the directory structure and interact poorly with groups. It shouldn't be a big deal to store all the secrets in one file and distinguish environments by name, but if anyone has an idea on how to do it better let me know.