### PR TITLE
Use env-specific secrets file instead of a global one

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,23 +94,24 @@ First, let's look at the basic structure of a `tf` infrastructure project and th
 Describes the purpose and contents of the infrastructure project.
 
 ### `config`
-Contains configuration files in [tfvars format](https://www.terraform.io/intro/getting-started/variables.html#from-a-file) that define the infrastructure for the region and environment. A *defaults* or *common* tfvars file is required and should define reasonable defaults to be used across environments. You may also include a *secrets* tfvars file, which allows you to store secrets using a tool like [git-crypt](https://github.com/AGWA/git-crypt) while keeping the rest of your configuration in plain text, but this file is not required.
+Contains configuration files in [tfvars format](https://www.terraform.io/intro/getting-started/variables.html#from-a-file) that define the infrastructure for the region and environment. A *defaults* or *common* tfvars file is required and should define reasonable defaults to be used across environments.
 
-Environment specific variables must be defined in the appropriate environment tfvars file. The environment config file name maps to the &lt;env&gt; argument when `tf` is invoked.
+Environment specific variables must be defined in the appropriate environment tfvars file. The environment config file name maps to the &lt;env&gt; argument when `tf` is invoked. `tf` will also check for a file called `${env}-secrets.tfvars`, and load it if it exists. This allows you to store secrets using a tool like [git-crypt](https://github.com/AGWA/git-crypt) while keeping the rest of your configuration in plain text. The secrets file is not required.
 
 A project may need to further differentiate by *group* when it is necessary to deploy multiple groups of the same infrastructure in the same environment. For example, multiple ECS services exist in an ECS cluster and therefore groups are needed to define their unique configuration. Group variables must exist in a directory with the same name as the environment. For example, an ECS service config directory structure may look like:
 
     ├── config
     │   ├── defaults.tfvars
-    │   ├── secrets.tfvars
     │   ├── production
     │   │   ├── mongo-state-sp.tfvars
     │   │   └── domain-event-sp.tfvars
     │   ├── production.tfvars
+    │   ├── production-secrets.tfvars
     │   ├── staging
     │   │   ├── mongo-state-sp.tfvars
     │   │   ├── domain-event-sp.tfvars
     │   └── staging.tfvars
+    │   └── staging-secrets.tfvars
 
 Given this structure, a command to apply infrastructure might be:
 

--- a/tf
+++ b/tf
@@ -166,8 +166,8 @@ function runCommand(args, terraformArgs, opts) {
   }
 
   // add secrets var file
-  if (fs.existsSync(`${args.cwd}/${args.project}/config/secrets.tfvars`)) {
-    runArgs.push(`-var-file=../config/secrets.tfvars`);
+  if (fs.existsSync(`${args.cwd}/${args.project}/config/${args.env}-secrets.tfvars`)) {
+    runArgs.push(`-var-file=../config/${args.env}-secrets.tfvars`);
   }
 
   // set extra vars


### PR DESCRIPTION
As soon as I tried to use this secrets file I realized it would be a lot nicer to do env-specific ones, and that it's not hard either :)

This switches from a single `config/secrets.tfvars` to env-specific `${env}-secrets.tfvars`. Interpolating the name instead of putting the secrets file in the subdirectory avoids conflating secrets with groups.