### PR TITLE
update command-exists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
     },
     "command-exists": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.2.tgz",
-      "integrity": "sha1-EoGcZPr5VEbsCuB/5sr7brNwiyI="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.7.tgz",
+      "integrity": "sha512-doWDvhXCcW5LK0cIUWrOQ8oMFXJv3lEQCkJpGVjM8v9SV0uhqYXB943538tEA2CiaWqSyuYUGAm5ezDwEx9xlw=="
     },
     "commander": {
       "version": "2.12.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/HustleInc/tf#readme",
   "dependencies": {
     "colors": "^1.1.2",
-    "command-exists": "^1.2.2",
+    "command-exists": "^1.2.7",
     "commander": "^2.11.0"
   }
 }


### PR DESCRIPTION
Fix vulnerability with `command-exists` dependancy.

```
➤  npm audit

                       === npm audit security report ===

# Run  npm install command-exists@1.2.7  to resolve 1 vulnerability
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Critical      │ Command Injection                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ command-exists                                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ command-exists                                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ command-exists                                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/659                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
```